### PR TITLE
feat(examples): add structure and Python RAG walkthrough

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -1,0 +1,69 @@
+name: examples-smoke
+
+on:
+  schedule:
+    # 09:00 UTC every Monday — catch SDK drift before the work week starts.
+    - cron: "0 9 * * MON"
+  pull_request:
+    paths:
+      - "examples/**"
+      - ".github/workflows/examples-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - ".github/workflows/examples-smoke.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: examples-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: ${{ matrix.os }} · python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+    env:
+      CEREBE_API_KEY: ${{ secrets.CEREBE_API_KEY }}
+      CEREBE_BASE_URL: https://api.cerebe.ai
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run smoke tests for every Python example
+        shell: bash
+        run: |
+          set -euo pipefail
+          failed=0
+          for dir in examples/*/python; do
+            [ -f "$dir/Makefile" ] || continue
+            echo "::group::$dir"
+            (
+              cd "$dir"
+              # Upgrade the SDK to the current latest — this is the drift check.
+              uv sync --extra dev --upgrade-package cerebe
+              make test
+            ) || failed=1
+            echo "::endgroup::"
+          done
+          exit $failed
+
+      - name: Upload pytest logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-logs-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: |
+            examples/**/.pytest_cache/**
+            examples/**/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -31,6 +31,10 @@ jobs:
     env:
       CEREBE_API_KEY: ${{ secrets.CEREBE_API_KEY }}
       CEREBE_BASE_URL: https://api.cerebe.ai
+      # Force uv to use the matrix-specified Python for sync + run.
+      # Without this, uv picks its default (newest installed) and the
+      # Python-version matrix becomes cosmetic.
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Environment / secrets
+.env
+.env.local
+.env.*.local
+
+# Internal planning artifacts (superpowers specs/plans — not for public repo)
+docs/superpowers/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.egg-info/
+dist/
+build/
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE / OS
+.DS_Store
+.idea/
+.vscode/
+*.swp

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Cerebe provides cognitive infrastructure as an API:
 - **Agent Tooling** — Execution traces, cognitive profiling, and MCP server for Claude Code and Cursor.
 - **LLM Router** — OpenAI-compatible chat with automatic cognitive context enrichment.
 
+## Examples
+
+Runnable examples live under [`examples/`](./examples/). Each is a stand-alone, clone-and-run walkthrough with its own README, dependency manifest, and live-API smoke tests — no platform-side setup required.
+
+- [**RAG**](./examples/rag/) — embed documents, run semantic + hybrid search, and manage a Cerebe-backed knowledge base with `client.rag`.
+
+See [`examples/README.md`](./examples/README.md) for the full index and contribution conventions.
+
 ## Quick Start
 
 ### Install

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,46 @@
+# Cerebe Examples
+
+Runnable examples that show how to use the Cerebe platform. Each example is self-contained — clone the repo, `cd` into it, follow its README, and it works.
+
+Every example lives under `examples/<topic>/<language>/`. The language subdirectory is always present (even when only one language ships today) so that deep links stay stable as more languages are added.
+
+## Available examples
+
+| Topic | What you'll learn | Python | TypeScript |
+|-------|-------------------|:------:|:----------:|
+| [RAG](./rag/) | Embed, search, hybrid-search, and manage documents using `client.rag` | [✓](./rag/python/) | — |
+
+## Conventions
+
+Every example ships:
+
+- A `README.md` with a 30-second quickstart, prereqs, expected output, and troubleshooting.
+- A dependency manifest (`pyproject.toml` for Python, `package.json` for TypeScript) pinning a minimum SDK version that exposes the feature it demonstrates.
+- An `.env.example` template for `CEREBE_API_KEY` and `CEREBE_BASE_URL`.
+- A `Makefile` with `install`, `demo`, `test`, and `clean` targets — so the UX is the same regardless of the underlying toolchain.
+- A guided demo entrypoint (`demo.py` / `demo.ts`) that succeeds or fails with actionable output.
+- Live-API smoke tests (no mocks, no recorded fixtures) that self-clean and skip cleanly when `CEREBE_API_KEY` isn't set.
+
+## Getting an API key
+
+Grab one from the [Cerebe Dashboard](https://cerebe.ai/dashboard/keys). Keys starting with `ck_live_` hit production; `ck_test_` keys hit the test environment. Put your key in a local `.env` file inside the example directory — `.env` is gitignored.
+
+## Running an example
+
+```bash
+cd examples/rag/python
+cp .env.example .env
+# edit .env and paste your CEREBE_API_KEY
+make install
+make demo
+```
+
+Each example's README has the full walkthrough.
+
+## Contributing a new example
+
+1. Pick a topic folder name (kebab-case, one word or two).
+2. Create `examples/<topic>/README.md` (language-agnostic overview) and `examples/<topic>/<lang>/` with all the artifacts above.
+3. Pin the current-latest published SDK version in your manifest.
+4. Add a row to the table in this README.
+5. The scheduled CI workflow picks up new examples automatically — no workflow edits needed.

--- a/examples/rag/README.md
+++ b/examples/rag/README.md
@@ -1,0 +1,23 @@
+# RAG example
+
+Demonstrates Cerebe's **Retrieval-Augmented Generation** surface — `client.rag` — end-to-end. You'll embed a small corpus of markdown documents, run three kinds of search (semantic, hybrid, similarity), inspect collection stats, and clean up, all from a single guided script.
+
+## Languages
+
+- **Python** — [`./python/`](./python/) — ready to run today.
+- TypeScript — coming soon.
+
+## What this example teaches
+
+- How to authenticate the SDK with an API key.
+- How to embed one or many documents (`embed`, `embed_batch`).
+- How to retrieve chunks three different ways (`search`, `hybrid_search`, `find_similar`).
+- How to inspect and manage the collection (`stats`, `list_documents`, `delete_document`).
+- What a Cerebe RAG response looks like in practice — scores, metadata, request IDs.
+
+## Prerequisites
+
+- A Cerebe API key with the RAG scopes enabled. Grab or rotate one at the [Cerebe Dashboard](https://cerebe.ai/dashboard/keys).
+- The toolchain for the language variant you pick (see the language README for exact versions).
+
+Head into the language directory to get started.

--- a/examples/rag/python/.env.example
+++ b/examples/rag/python/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env and fill in your API key.
+# .env is gitignored; .env.example is committed as a template.
+
+# Your Cerebe API key — grab one from https://cerebe.ai/dashboard/keys
+# Production keys start with ck_live_, test keys start with ck_test_.
+# The key must have RAG scopes enabled (rag:read, rag:write, rag:delete).
+CEREBE_API_KEY=ck_live_replace_me
+
+# The Cerebe API base URL. You usually don't need to change this.
+CEREBE_BASE_URL=https://api.cerebe.ai

--- a/examples/rag/python/Makefile
+++ b/examples/rag/python/Makefile
@@ -1,0 +1,20 @@
+.PHONY: install demo test clean help
+
+help:
+	@echo "Targets:"
+	@echo "  install  Install dependencies (uv sync)"
+	@echo "  demo     Run the guided RAG walkthrough"
+	@echo "  test     Run live smoke tests against the real Cerebe API"
+	@echo "  clean    Remove the local .venv and caches"
+
+install:
+	uv sync --extra dev
+
+demo:
+	uv run python demo.py
+
+test:
+	uv run pytest -v
+
+clean:
+	rm -rf .venv .pytest_cache __pycache__ */__pycache__

--- a/examples/rag/python/README.md
+++ b/examples/rag/python/README.md
@@ -1,0 +1,115 @@
+# RAG example · Python
+
+A single-file, guided walkthrough of every method on Cerebe's `client.rag`: embed documents, search (three ways), inspect the collection, and clean up — all against a real Cerebe API.
+
+## 30-second quickstart
+
+```bash
+# 1. clone the repo and enter this directory
+git clone https://github.com/momentiq-ai/cerebe.git
+cd cerebe/examples/rag/python
+
+# 2. set your API key
+cp .env.example .env
+# open .env and paste your key (get one at https://cerebe.ai/dashboard/keys)
+# the key must have RAG scopes: rag:read, rag:write, rag:delete
+
+# 3. install dependencies
+make install
+
+# 4. run the demo
+make demo
+```
+
+## Prerequisites
+
+- Python **3.11**, **3.12**, or **3.13**.
+- [`uv`](https://docs.astral.sh/uv/) installed (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+- A Cerebe API key with RAG scopes. Grab one at [cerebe.ai/dashboard/keys](https://cerebe.ai/dashboard/keys).
+
+No other platform-side setup is required.
+
+## What this example teaches
+
+- How to authenticate the SDK from an environment variable.
+- How to ingest a batch of markdown files with `embed_batch`.
+- How `search`, `hybrid_search`, and `find_similar` differ (score breakdown included).
+- How to inspect and clean up a collection with `stats`, `list_documents`, and `delete_document`.
+- How to write live-API smoke tests that self-clean.
+
+## What's in this directory
+
+| File | Purpose |
+|------|---------|
+| `demo.py` | Guided CLI walkthrough — seven steps, each with timing and status |
+| `test_rag.py` | Five live smoke tests (`pytest`) |
+| `sample_docs/` | Five markdown files used as the demo corpus |
+| `pyproject.toml` | PEP 621 manifest pinning `cerebe>=0.5.0` |
+| `Makefile` | `install` / `demo` / `test` / `clean` |
+| `.env.example` | Template for `CEREBE_API_KEY`, `CEREBE_BASE_URL` |
+
+## Expected output
+
+Running `make demo` against a working key prints a sequence of `rich` panels. Abridged:
+
+```
+╭────────────── step 1 - config ──────────────╮
+│ Cerebe RAG Example                          │
+│ base URL : https://api.cerebe.ai            │
+│ API key  : ck_live_...xyz                   │
+│ sample_docs : .../sample_docs               │
+╰─────────────────────────────────────────────╯
+╭──────── step 2 - preflight (833ms) ─────────╮
+│ OK - API reachable                          │
+│ collection at start: {...}                  │
+╰─────────────────────────────────────────────╯
+╭─────── step 3 - ingest (3623ms) ────────────╮
+│             Ingested documents              │
+│ ┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┓  │
+│ ┃ source                ┃ chunks ┃ bytes ┃  │
+│ ┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━┩  │
+│ │ .../authentication.md │      2 │  1840 │  │
+│ │ .../knowledge-…       │      3 │  1935 │  │
+│ │ .../memory-fabric.md  │      4 │  2151 │  │
+│ │ .../observability.md  │      3 │  2154 │  │
+│ │ .../rag.md            │      3 │  2245 │  │
+│ └───────────────────────┴────────┴───────┘  │
+╰─────────────────────────────────────────────╯
+
+... (step 4a/b/c: search, hybrid_search, find_similar — each with top-3 table)
+... (step 5: collection summary)
+... (step 6: cleanup — deleted: 5, failures: 0)
+
+╭──────── step 7 - summary ────────╮
+│ every step OK, exit code 0       │
+╰──────────────────────────────────╯
+```
+
+Exit code `0` on success, `1` if any step fails. Pass `--verbose` for full tracebacks when debugging.
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `make install` | Creates `.venv/` and installs deps via `uv sync --extra dev` |
+| `make demo` | Runs the guided walkthrough end-to-end |
+| `make test` | Runs live smoke tests (skips cleanly if `CEREBE_API_KEY` isn't set) |
+| `make clean` | Removes `.venv/` and pytest caches |
+
+## Troubleshooting
+
+**`Authentication failed (HTTP 401)`** — your key is wrong, missing, or revoked. Check `.env`; rotate at [cerebe.ai/dashboard/keys](https://cerebe.ai/dashboard/keys).
+
+**`Permission denied (HTTP 403)`** — your key is valid but lacks a required scope. The demo needs `rag:read`, `rag:write`, and `rag:delete`. Grant them in the dashboard under the key's settings.
+
+**`Could not reach the Cerebe API`** — network or DNS issue. Confirm with `curl https://api.cerebe.ai/api/v1/rag/stats -H "X-API-Key: $CEREBE_API_KEY"`.
+
+**`Rate limit hit (HTTP 429)`** — slow down or use a different key. If it happens in CI, use a dedicated CI key.
+
+**`CEREBE_API_KEY is not set`** — you haven't created `.env` yet. `cp .env.example .env` and paste your key.
+
+**Import error for `cerebe`** — you skipped `make install`. Run it first.
+
+## Cleanup
+
+The demo and the tests clean up after themselves (they delete every document they create, using a unique session prefix so parallel runs can't clobber each other). If something crashes mid-run and leaves orphan sources, they're prefixed `rag-demo-<hex>/…` or `test-rag-<hex>/…` — you can see and delete them from the dashboard or with `client.rag.list_documents()` / `client.rag.delete_document()`.

--- a/examples/rag/python/demo.py
+++ b/examples/rag/python/demo.py
@@ -1,0 +1,356 @@
+"""Cerebe RAG walkthrough — embed, search, and manage documents end-to-end.
+
+Run: `make demo` (or `uv run python demo.py`).
+
+Pass `--verbose` to print full tracebacks on failure.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+SAMPLE_DOCS_DIR = Path(__file__).parent / "sample_docs"
+
+
+@dataclass
+class StepResult:
+    name: str
+    status: str  # "ok", "fail", "skip"
+    elapsed_ms: float
+    note: str = ""
+
+
+@dataclass
+class RunState:
+    console: Console
+    verbose: bool
+    results: list[StepResult] = field(default_factory=list)
+
+    def record(self, name: str, status: str, elapsed_ms: float, note: str = "") -> None:
+        self.results.append(StepResult(name=name, status=status, elapsed_ms=elapsed_ms, note=note))
+
+
+def mask_key(key: str) -> str:
+    if not key:
+        return "<unset>"
+    if len(key) <= 12:
+        return key[:3] + "..."
+    return f"{key[:8]}...{key[-3:]}"
+
+
+def load_config() -> tuple[str, str]:
+    load_dotenv()
+    key = os.environ.get("CEREBE_API_KEY", "").strip()
+    base_url = os.environ.get("CEREBE_BASE_URL", "https://api.cerebe.ai").strip()
+    if not key:
+        raise SystemExit(
+            "CEREBE_API_KEY is not set.\n"
+            "  1. Copy `.env.example` to `.env`\n"
+            "  2. Paste your key (get one at https://cerebe.ai/dashboard/keys)\n"
+            "  3. Re-run `make demo`"
+        )
+    return key, base_url
+
+
+def explain_error(exc: BaseException) -> str:
+    """Map common failures to actionable next steps."""
+    msg = str(exc)
+    name = type(exc).__name__
+    lower = msg.lower()
+    if "401" in msg or "unauthori" in lower or "invalid api key" in lower:
+        return (
+            "Authentication failed (HTTP 401). Your CEREBE_API_KEY is missing, "
+            "invalid, or revoked. Check the value in `.env` and rotate it at "
+            "https://cerebe.ai/dashboard/keys if needed."
+        )
+    if "403" in msg or "insufficient_scope" in lower or "forbidden" in lower:
+        return (
+            "Permission denied (HTTP 403). Your key is valid but lacks the "
+            "required scope for this operation. For the RAG example you need "
+            "rag:read, rag:write, and rag:delete. Update scopes at "
+            "https://cerebe.ai/dashboard/keys."
+        )
+    if "429" in msg or "rate limit" in lower:
+        return (
+            "Rate limit hit (HTTP 429). Slow down or use a different key. "
+            "If this happens in CI, consider a dedicated key."
+        )
+    if "connection" in lower or "dns" in lower or "timed out" in lower or "timeout" in lower:
+        return (
+            "Could not reach the Cerebe API. Check your network and verify "
+            "CEREBE_BASE_URL is reachable (default https://api.cerebe.ai)."
+        )
+    if "404" in msg:
+        return f"Got HTTP 404 — the resource was not found. Raw: {msg}"
+    return f"{name}: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Steps
+# ---------------------------------------------------------------------------
+
+def banner(state: RunState, api_key: str, base_url: str) -> None:
+    state.console.print(
+        Panel.fit(
+            (
+                "[bold]Cerebe RAG Example[/bold]\n"
+                f"base URL : [cyan]{base_url}[/cyan]\n"
+                f"API key  : [cyan]{mask_key(api_key)}[/cyan]\n"
+                f"sample_docs : [cyan]{SAMPLE_DOCS_DIR}[/cyan]"
+            ),
+            title="step 1 - config",
+            border_style="blue",
+        )
+    )
+    state.record("config", "ok", 0.0, f"base_url={base_url}")
+
+
+def preflight(state: RunState, client) -> None:
+    t0 = time.perf_counter()
+    try:
+        resp = client.rag.stats()
+        data = getattr(resp, "data", {}) or {}
+        elapsed = (time.perf_counter() - t0) * 1000
+        state.console.print(
+            Panel(
+                f"[green]OK - API reachable[/green]\n"
+                f"collection at start: [bold]{data}[/bold]",
+                title=f"step 2 - preflight ({elapsed:.0f}ms)",
+                border_style="green",
+            )
+        )
+        state.record("preflight", "ok", elapsed, str(data))
+    except Exception as exc:
+        elapsed = (time.perf_counter() - t0) * 1000
+        state.console.print(
+            Panel(
+                f"[red]FAIL - preflight failed[/red]\n{explain_error(exc)}",
+                title=f"step 2 - preflight ({elapsed:.0f}ms)",
+                border_style="red",
+            )
+        )
+        if state.verbose:
+            traceback.print_exc()
+        state.record("preflight", "fail", elapsed, explain_error(exc))
+        raise
+
+
+def ingest(state: RunState, client, session_prefix: str) -> list[str]:
+    t0 = time.perf_counter()
+    documents = []
+    for path in sorted(SAMPLE_DOCS_DIR.glob("*.md")):
+        documents.append(
+            {
+                "source": f"{session_prefix}/{path.name}",
+                "content": path.read_text(),
+                "doc_type": "markdown",
+                "metadata": {"example": "rag", "filename": path.name},
+            }
+        )
+
+    resp = client.rag.embed_batch(documents)
+    elapsed = (time.perf_counter() - t0) * 1000
+
+    table = Table(title="Ingested documents", show_lines=False)
+    table.add_column("source")
+    table.add_column("chunks", justify="right")
+    table.add_column("bytes", justify="right")
+
+    data = getattr(resp, "data", {}) or {}
+    per_doc = data.get("results") or data.get("documents") or []
+    if not per_doc:
+        for doc in documents:
+            table.add_row(doc["source"], "?", str(len(doc["content"])))
+    else:
+        # zip by order; if lengths differ, fall back to showing what we sent
+        for entry, doc in zip(per_doc, documents):
+            chunks = entry.get("chunks_created") or entry.get("chunks") or "?"
+            table.add_row(doc["source"], str(chunks), str(len(doc["content"])))
+
+    state.console.print(Panel.fit(table, title=f"step 3 - ingest ({elapsed:.0f}ms)", border_style="green"))
+    state.record("ingest", "ok", elapsed, f"{len(documents)} docs")
+    return [d["source"] for d in documents]
+
+
+def render_results(title: str, results: list[dict], elapsed_ms: float, console: Console, hybrid: bool = False) -> None:
+    table = Table(title=title, show_lines=False)
+    table.add_column("source", overflow="fold")
+    table.add_column("snippet", overflow="fold")
+    if hybrid:
+        table.add_column("sem", justify="right")
+        table.add_column("kw", justify="right")
+        table.add_column("score", justify="right")
+    else:
+        table.add_column("score", justify="right")
+
+    for row in results[:3]:
+        source = row.get("source", "?")
+        snippet = (row.get("content") or row.get("snippet") or "")[:140].replace("\n", " ")
+        score = row.get("score")
+        score_str = f"{score:.3f}" if isinstance(score, (int, float)) else str(score)
+        if hybrid:
+            semantic = row.get("semantic_score")
+            keyword = row.get("keyword_score")
+            table.add_row(
+                source,
+                snippet,
+                f"{semantic:.3f}" if isinstance(semantic, (int, float)) else str(semantic),
+                f"{keyword:.3f}" if isinstance(keyword, (int, float)) else str(keyword),
+                score_str,
+            )
+        else:
+            table.add_row(source, snippet, score_str)
+
+    console.print(Panel.fit(table, title=f"{title} ({elapsed_ms:.0f}ms)", border_style="cyan"))
+
+
+def search_phase(state: RunState, client) -> None:
+    t0 = time.perf_counter()
+    resp = client.rag.search("how do I authenticate with Cerebe?", k=3)
+    results = (getattr(resp, "data", {}) or {}).get("results") or []
+    elapsed = (time.perf_counter() - t0) * 1000
+    render_results("step 4a - search", results, elapsed, state.console)
+    state.record("search", "ok" if results else "fail", elapsed, f"{len(results)} results")
+
+    t0 = time.perf_counter()
+    resp = client.rag.hybrid_search(
+        "nine memory types", k=3, semantic_weight=0.7, keyword_weight=0.3
+    )
+    results = (getattr(resp, "data", {}) or {}).get("results") or []
+    elapsed = (time.perf_counter() - t0) * 1000
+    render_results("step 4b - hybrid_search", results, elapsed, state.console, hybrid=True)
+    state.record("hybrid_search", "ok" if results else "fail", elapsed, f"{len(results)} results")
+
+    t0 = time.perf_counter()
+    rag_md = (SAMPLE_DOCS_DIR / "rag.md").read_text()
+    # Take the first non-title paragraph as the similarity query.
+    parts = [p for p in rag_md.split("\n\n") if p.strip() and not p.strip().startswith("#")]
+    query = parts[0][:400] if parts else rag_md[:400]
+    resp = client.rag.find_similar(query, k=3)
+    results = (getattr(resp, "data", {}) or {}).get("results") or []
+    elapsed = (time.perf_counter() - t0) * 1000
+    render_results("step 4c - find_similar", results, elapsed, state.console)
+    state.record("find_similar", "ok" if results else "fail", elapsed, f"{len(results)} results")
+
+
+def collection_summary(state: RunState, client) -> None:
+    t0 = time.perf_counter()
+    stats = client.rag.stats()
+    docs = client.rag.list_documents()
+    elapsed = (time.perf_counter() - t0) * 1000
+
+    stats_data = getattr(stats, "data", {}) or {}
+    docs_data = getattr(docs, "data", {}) or {}
+    doc_count = len(docs_data.get("documents") or [])
+    total_reported = docs_data.get("total_documents")
+
+    state.console.print(
+        Panel.fit(
+            (
+                f"[bold]stats[/bold]: {stats_data}\n"
+                f"[bold]documents[/bold]: {doc_count} listed"
+                + (f" (total_documents={total_reported})" if total_reported is not None else "")
+            ),
+            title=f"step 5 - collection summary ({elapsed:.0f}ms)",
+            border_style="magenta",
+        )
+    )
+    state.record("summary", "ok", elapsed)
+
+
+def cleanup(state: RunState, client, sources: list[str]) -> None:
+    t0 = time.perf_counter()
+    deleted = 0
+    failures = 0
+    for source in sources:
+        try:
+            client.rag.delete_document(source)
+            deleted += 1
+        except Exception as exc:
+            failures += 1
+            state.console.print(f"[yellow]warn: cleanup failed for {source}: {explain_error(exc)}[/yellow]")
+    elapsed = (time.perf_counter() - t0) * 1000
+    status = "ok" if failures == 0 else "fail"
+    state.console.print(
+        Panel.fit(
+            f"[green]deleted[/green]: {deleted}\n[yellow]failures[/yellow]: {failures}",
+            title=f"step 6 - cleanup ({elapsed:.0f}ms)",
+            border_style="green" if failures == 0 else "yellow",
+        )
+    )
+    state.record("cleanup", status, elapsed, f"{deleted} deleted, {failures} failed")
+
+
+def final_summary(state: RunState) -> int:
+    table = Table(title="Summary", show_lines=True)
+    table.add_column("step")
+    table.add_column("status")
+    table.add_column("elapsed", justify="right")
+    table.add_column("notes", overflow="fold")
+
+    exit_code = 0
+    for r in state.results:
+        marker = {"ok": "[green]OK[/green]", "fail": "[red]FAIL[/red]", "skip": "[yellow]SKIP[/yellow]"}.get(r.status, r.status)
+        table.add_row(r.name, marker, f"{r.elapsed_ms:.0f} ms", r.note)
+        if r.status == "fail":
+            exit_code = 1
+
+    state.console.print(Panel.fit(table, title="step 7 - summary", border_style="blue" if exit_code == 0 else "red"))
+    return exit_code
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cerebe RAG walkthrough")
+    parser.add_argument("--verbose", action="store_true", help="print full tracebacks on failure")
+    args = parser.parse_args()
+
+    console = Console()
+    state = RunState(console=console, verbose=args.verbose)
+
+    try:
+        from cerebe import Cerebe
+    except ImportError:
+        console.print("[red]The `cerebe` package is not installed. Run `make install` first.[/red]")
+        return 1
+
+    api_key, base_url = load_config()
+    client = Cerebe(api_key=api_key, base_url=base_url)
+
+    banner(state, api_key, base_url)
+
+    try:
+        preflight(state, client)
+    except Exception:
+        return final_summary(state)
+
+    session_prefix = f"rag-demo-{uuid.uuid4().hex[:8]}"
+    sources: list[str] = []
+    try:
+        sources = ingest(state, client, session_prefix)
+        search_phase(state, client)
+        collection_summary(state, client)
+    except Exception as exc:
+        console.print(f"[red]{explain_error(exc)}[/red]")
+        if args.verbose:
+            traceback.print_exc()
+        state.record("error", "fail", 0.0, explain_error(exc))
+    finally:
+        if sources:
+            cleanup(state, client, sources)
+
+    return final_summary(state)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/rag/python/pyproject.toml
+++ b/examples/rag/python/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "cerebe-example-rag"
+version = "0.1.0"
+description = "Cerebe RAG walkthrough — embed, search, and manage documents."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "momentiq ai", email = "hello@momentiq.ai" }]
+
+dependencies = [
+  "cerebe>=0.5.0",
+  "python-dotenv>=1.0",
+  "rich>=13.7",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+]
+
+[tool.uv]
+package = false

--- a/examples/rag/python/sample_docs/authentication.md
+++ b/examples/rag/python/sample_docs/authentication.md
@@ -1,0 +1,38 @@
+# Authentication
+
+Every Cerebe API request is authenticated with an API key sent as the `X-API-Key` header. Keys are created in the [Cerebe Dashboard](https://cerebe.ai/dashboard/keys).
+
+## Key formats
+
+Cerebe issues two key variants:
+
+- `ck_live_…` — production keys. These bill the org's production workspace and can read/write live data.
+- `ck_test_…` — test keys. These target the sandbox environment. Use test keys in CI and local development.
+
+Both variants have the same request shape — only the key prefix and backing environment differ.
+
+## Sending the key
+
+Every HTTPS request must include the header `X-API-Key: ck_live_your_key`. There is no query-string variant and no basic-auth fallback.
+
+```bash
+curl https://api.cerebe.ai/api/v1/memory/search \
+  -H "X-API-Key: ck_live_your_key" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "user preferences", "entity_id": "user_123"}'
+```
+
+The Python and TypeScript SDKs accept the key via constructor:
+
+```python
+from cerebe import Cerebe
+client = Cerebe(api_key="ck_live_...")
+```
+
+## Rotation and scoping
+
+Keys can be revoked and rotated from the dashboard at any time. A revoked key returns `401 Unauthorized` on the next request. Best practice is to scope a distinct key per deployment (one for production, one for staging, one per CI job) so that rotating one does not affect others.
+
+## Handling auth errors
+
+A request with an invalid, missing, or revoked key returns HTTP 401 with a JSON body describing the cause. A request with a valid key that lacks the required scope returns HTTP 403 with an `insufficient_scope` error and the name of the missing scope. Applications should surface a concrete next step ("check your `CEREBE_API_KEY` environment variable", "grant `rag:read` to your key in the dashboard") rather than exposing the raw server error to end users.

--- a/examples/rag/python/sample_docs/knowledge-graphs.md
+++ b/examples/rag/python/sample_docs/knowledge-graphs.md
@@ -1,0 +1,23 @@
+# Knowledge Graphs
+
+Cerebe's knowledge-graph surface (`client.knowledge`) stores facts and the relationships between them, and preserves how that knowledge evolves over time. Use it when you need to reason about connections — who is related to whom, which project depends on which, what changed when — rather than retrieve matching text.
+
+## Ingest
+
+New facts enter the graph through `client.knowledge.ingest`. You can pass raw text (the platform extracts entities and relationships) or structured triples when you already have them. Each ingested fact carries provenance — the source document and the ingestion timestamp — so you can always trace a claim back to its origin.
+
+## Query
+
+`client.knowledge.query` returns matching nodes or edges. Queries support property filters, relationship types, and hop count. Unlike RAG search, results come back as typed graph nodes with their attributes, not prose chunks.
+
+## Traverse
+
+`client.knowledge.traverse` walks outward from a starting node. You specify the start, the edge types to follow, and the maximum depth. Traversal is how you answer "what projects does this person own?" or "which memory items cite this document?" Cycles are detected and reported rather than expanded forever.
+
+## Temporal evolution
+
+The graph is temporal: facts have valid-from and valid-to timestamps, and queries can be scoped to "as of" a particular moment. This matters when the truth changes — an employee's role, a product's availability, a policy's text. Rather than overwriting, ingesting a contradicting fact creates a new temporal edge and closes out the old one, and the full history is traversable.
+
+## Visualise
+
+`client.knowledge.visualize` produces a renderable representation of a subgraph — the set of nodes and edges around a focal node — suitable for drawing in the dashboard or exporting to tools like Graphviz. Use it to sanity-check what the graph actually contains for a given entity.

--- a/examples/rag/python/sample_docs/memory-fabric.md
+++ b/examples/rag/python/sample_docs/memory-fabric.md
@@ -1,0 +1,33 @@
+# Memory Fabric
+
+Most AI applications are stateless — every conversation starts from scratch. Cerebe's Memory Fabric gives applications persistent memory that lasts across sessions, users, and weeks.
+
+## The nine memory types
+
+Memory Fabric is organised into nine distinct memory types, each with its own retention, recall, and consolidation behaviour:
+
+1. **Semantic** — facts about the world and the user (preferences, traits, stable beliefs).
+2. **Episodic** — time-anchored events and conversations ("on Tuesday the user mentioned they prefer visual explanations").
+3. **Procedural** — how to do things; sequences of actions the agent has seen work.
+4. **Working** — short-horizon scratch space scoped to the current session.
+5. **Sensory** — raw inputs (text, audio transcripts, images) with minimal processing.
+6. **Prospective** — intentions and reminders scheduled for the future.
+7. **Associative** — links between memory items to enable graph traversal.
+8. **Meta** — memory about memory (confidence, provenance, last-accessed).
+9. **TTL** — any of the above with an explicit time-to-live for compliance or privacy.
+
+## Hybrid storage
+
+Memory Fabric stores items in a **hybrid vector + graph** substrate. Vector similarity handles "give me memories semantically related to this query"; graph traversal handles "what is connected to this memory and how." Both are available through the same `client.memory` surface.
+
+## Consolidation
+
+Raw memories are frequently noisy. Cerebe's **consolidate** endpoint compresses a window of episodic memories into higher-quality semantic summaries while preserving provenance. This keeps search fast and the knowledge base compact.
+
+## Harvest
+
+The **harvest** endpoint extracts long-term-worthy facts from a recent stream of interactions and promotes them into the appropriate memory type. Use it to bridge a live session into persistent memory at the end of a conversation.
+
+## When to use it
+
+Memory Fabric is the right layer for any application that needs to remember *about users* across sessions. For document-level knowledge that doesn't change per user, use the RAG surface (`client.rag`) instead.

--- a/examples/rag/python/sample_docs/observability.md
+++ b/examples/rag/python/sample_docs/observability.md
@@ -1,0 +1,30 @@
+# Observability
+
+Cerebe's observability surface makes agent behaviour inspectable. Every interaction an agent has with the platform — memory reads and writes, RAG queries, chat completions — is captured as a structured trace you can replay, analyse, and alert on.
+
+## Traces
+
+An **execution trace** is the complete sequence of steps the agent took to produce a response: which memories it read, which documents it retrieved, which tools it called, and which LLM calls it made, all with timestamps and token counts. Traces are exposed through `client.agents.traces` and are retrievable by trace ID, by user, or by time range.
+
+Each span in a trace records:
+
+- The operation name (e.g. `memory.search`, `rag.hybrid_search`, `llm.chat`).
+- Inputs (query text, filters) and outputs (result count, score distribution).
+- Latency (wall-clock and server time).
+- Any errors raised and their class.
+
+## Cognitive profiling
+
+Beyond raw traces, Cerebe computes aggregate **cognitive profiles**: how does the agent spend its time across memory, retrieval, and reasoning? Which memory types does a user access most? Where are latency hotspots? These are helpful for tuning context-window usage and for debugging regressions when an agent's behaviour changes unexpectedly.
+
+## Using traces in development
+
+During development, pulling the most recent trace for a failed interaction is often faster than re-instrumenting your own logging. The dashboard shows each trace as a timeline with per-span latencies, and the API returns the same data structured so you can diff traces programmatically.
+
+## MCP for Claude Code and Cursor
+
+Cerebe ships an MCP server that exposes traces, memory, and the RAG surface to AI-coding tools like Claude Code and Cursor. Developers debugging an application against Cerebe can query traces directly from their editor without switching to the dashboard.
+
+## Privacy
+
+Trace payloads include the prompts and responses that flowed through Cerebe. They live in the same workspace as your memory and knowledge data and inherit the same retention settings. If you need shorter retention for traces specifically, configure it in the dashboard.

--- a/examples/rag/python/sample_docs/rag.md
+++ b/examples/rag/python/sample_docs/rag.md
@@ -1,0 +1,25 @@
+# Retrieval-Augmented Generation
+
+Cerebe's RAG surface (`client.rag`) provides document embedding and retrieval for knowledge that doesn't change per user. Use it for product docs, knowledge bases, policies, and any corpus you want an agent to search against.
+
+## How it works
+
+When you embed a document, Cerebe chunks the content into overlapping windows, computes a vector embedding for each chunk, and stores both the raw text and its embedding against a unique `source` identifier. Later searches use that embedding index to return the most relevant chunks with similarity scores.
+
+## Search modes
+
+Three retrieval modes are available:
+
+- **Semantic search** (`search`) — vector similarity only. Best for conceptual questions where the answer may not use the same words as the query.
+- **Hybrid search** (`hybrid_search`) — weighted combination of semantic similarity and keyword match. Configurable weights (`semantic_weight`, `keyword_weight`) let you bias toward concept or lexical match depending on the query style. Results include both `semantic_score` and `keyword_score` so downstream code can see the breakdown, along with a combined `score` used for ranking.
+- **Similarity search** (`find_similar`) — take an existing piece of content and find other documents like it, without composing a text query.
+
+All three accept an optional `k` parameter (number of results) and optional filters on `doc_type` and, for `search`, `source_pattern`.
+
+## Document management
+
+Documents are identified by a `source` string you choose (a URL, a path, an ID — whatever makes sense for your application). `embed` adds or replaces a single document; `embed_batch` handles many at once and returns per-document chunk counts. `list_documents` enumerates what's stored, and `delete_document` removes a source along with all its chunks. `stats` returns a summary of the collection — total chunks, unique sources, doc-type breakdown, and the embedding model in use.
+
+## Metadata and doc types
+
+Every document can carry an optional `metadata` dict and a `doc_type` tag (default `"markdown"`). Use `doc_type` to separate different corpora (docs vs. policies vs. examples) when searching — the `doc_type` filter on `search` scopes results to a single type.

--- a/examples/rag/python/test_rag.py
+++ b/examples/rag/python/test_rag.py
@@ -1,0 +1,143 @@
+"""Live smoke tests for the RAG example.
+
+These hit the real Cerebe API — no mocks. Each test namespaces its state
+with a session ID so parallel runs don't collide, and the module-scoped
+fixture cleans up after itself on both pass and fail paths.
+
+Skips cleanly with an actionable message when CEREBE_API_KEY isn't set.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_KEY = os.environ.get("CEREBE_API_KEY", "").strip()
+BASE_URL = os.environ.get("CEREBE_BASE_URL", "https://api.cerebe.ai").strip()
+
+if not API_KEY:
+    pytest.skip(
+        "set CEREBE_API_KEY (e.g. in .env) to run live RAG smoke tests",
+        allow_module_level=True,
+    )
+
+
+SESSION_ID = f"test-rag-{uuid.uuid4().hex[:8]}"
+
+
+def _src(name: str) -> str:
+    return f"{SESSION_ID}/{name}"
+
+
+class _TrackingClient:
+    """Thin wrapper so tests can record sources they created for cleanup."""
+
+    def __init__(self, inner, created: list[str]) -> None:
+        self._inner = inner
+        self._created = created
+
+    @property
+    def rag(self):
+        return self._inner.rag
+
+    def track(self, source: str) -> None:
+        self._created.append(source)
+
+
+@pytest.fixture(scope="module")
+def client():
+    from cerebe import Cerebe
+
+    c = Cerebe(api_key=API_KEY, base_url=BASE_URL)
+    created: list[str] = []
+    yield _TrackingClient(c, created)
+
+    for source in created:
+        try:
+            c.rag.delete_document(source)
+        except Exception:
+            # best effort — never fail the suite on cleanup
+            pass
+
+
+def test_stats_reachable(client):
+    """API key + base URL work end-to-end."""
+    resp = client.rag.stats()
+    assert resp is not None
+    assert hasattr(resp, "data"), "response missing .data attribute"
+
+
+def test_embed_and_list(client):
+    """Embedding a doc makes it appear in list_documents."""
+    source = _src("embed_and_list.md")
+    client.rag.embed(
+        source=source,
+        content="Integration test marker — embed-and-list.",
+        doc_type="markdown",
+        metadata={"test": "embed_and_list"},
+    )
+    client.track(source)
+
+    resp = client.rag.list_documents()
+    documents = (getattr(resp, "data", {}) or {}).get("documents") or []
+    sources = [d.get("source") for d in documents]
+    assert source in sources, f"expected {source} in {sources[:10]}"
+
+
+def test_search_finds_embedded(client):
+    """Searching for a unique phrase returns the doc containing it."""
+    source = _src("search_finds.md")
+    marker = "zaphaelith anomaly protocol"  # a phrase that won't appear elsewhere
+    client.rag.embed(
+        source=source,
+        content=f"This document describes the {marker} in detail.",
+        doc_type="markdown",
+    )
+    client.track(source)
+
+    resp = client.rag.search(marker, k=5)
+    results = (getattr(resp, "data", {}) or {}).get("results") or []
+    sources = [r.get("source") for r in results]
+    assert source in sources, f"expected {source} in search results; got {sources}"
+
+
+def test_hybrid_search_returns_score_breakdown(client):
+    """hybrid_search responses carry both semantic_score and keyword_score."""
+    source = _src("hybrid_score.md")
+    client.rag.embed(
+        source=source,
+        content="Hybrid search combines semantic similarity with keyword matching.",
+        doc_type="markdown",
+    )
+    client.track(source)
+
+    resp = client.rag.hybrid_search(
+        "hybrid search scoring", k=3, semantic_weight=0.7, keyword_weight=0.3
+    )
+    results = (getattr(resp, "data", {}) or {}).get("results") or []
+    assert results, "expected at least one hybrid result"
+    first = results[0]
+    assert "semantic_score" in first, f"missing semantic_score in {list(first.keys())}"
+    assert "keyword_score" in first, f"missing keyword_score in {list(first.keys())}"
+
+
+def test_delete_removes_doc(client):
+    """Deleting a source removes it from list_documents."""
+    source = _src("delete_removes.md")
+    client.rag.embed(
+        source=source,
+        content="Will be deleted.",
+        doc_type="markdown",
+    )
+    client.track(source)
+
+    client.rag.delete_document(source)
+    # Once deleted, list_documents should no longer include it.
+    resp = client.rag.list_documents()
+    documents = (getattr(resp, "data", {}) or {}).get("documents") or []
+    sources = [d.get("source") for d in documents]
+    assert source not in sources, f"{source} still present after delete: {sources[:10]}"

--- a/examples/rag/python/test_rag.py
+++ b/examples/rag/python/test_rag.py
@@ -89,9 +89,17 @@ def test_embed_and_list(client):
 
 
 def test_search_finds_embedded(client):
-    """Searching for a unique phrase returns the doc containing it."""
+    """Searching for a unique phrase returns the doc containing it.
+
+    Scopes the search to the current test session via source_pattern so that
+    orphan vectors left behind by a previous run (e.g. interrupted cleanup)
+    don't interfere. Retries a few times to tolerate the brief embed→index
+    propagation delay.
+    """
+    import time
+
     source = _src("search_finds.md")
-    marker = "zaphaelith anomaly protocol"  # a phrase that won't appear elsewhere
+    marker = f"zaphaelith anomaly protocol {SESSION_ID}"
     client.rag.embed(
         source=source,
         content=f"This document describes the {marker} in detail.",
@@ -99,10 +107,18 @@ def test_search_finds_embedded(client):
     )
     client.track(source)
 
-    resp = client.rag.search(marker, k=5)
-    results = (getattr(resp, "data", {}) or {}).get("results") or []
-    sources = [r.get("source") for r in results]
-    assert source in sources, f"expected {source} in search results; got {sources}"
+    session_pattern = f"{SESSION_ID}/"  # source_pattern is a prefix match, not a glob
+    sources: list[str] = []
+    for _ in range(5):
+        resp = client.rag.search(marker, k=5, source_pattern=session_pattern)
+        results = (getattr(resp, "data", {}) or {}).get("results") or []
+        sources = [r.get("source") for r in results]
+        if source in sources:
+            return
+        time.sleep(0.5)
+    raise AssertionError(
+        f"expected {source} in search results within 2.5s; got {sources}"
+    )
 
 
 def test_hybrid_search_returns_score_breakdown(client):

--- a/examples/rag/python/uv.lock
+++ b/examples/rag/python/uv.lock
@@ -1,0 +1,360 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "cerebe"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/ee/487d83b444b97959dfc6b6c26077d904ea685e1c38e527c22ce980cdfcd6/cerebe-0.5.0.tar.gz", hash = "sha256:da8a3fa9ea0bb896a8684cf02d7cdac215165d391690c7e949c797c150e7cbb5", size = 31879, upload-time = "2026-04-19T19:58:43.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/2d/976a1e8a50c7a59e25875db15b1f14034e0e69817bcb6c7bcdfd576d0652/cerebe-0.5.0-py3-none-any.whl", hash = "sha256:018bf35ef845986d22c12adba00191173e29cfadd928cefe7d22f6ef08504690", size = 31206, upload-time = "2026-04-19T19:58:42.475Z" },
+]
+
+[[package]]
+name = "cerebe-example-rag"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "cerebe" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cerebe", specifier = ">=0.5.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "rich", specifier = ">=13.7" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/e5/06d23afac9973109d1e3c8ad38e1547a12e860610e327c05ee686827dc37/pydantic-2.13.2.tar.gz", hash = "sha256:b418196607e61081c3226dcd4f0672f2a194828abb9109e9cfb84026564df2d1", size = 843836, upload-time = "2026-04-17T09:31:59.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/ca/b45c378e6e8d0b90577288b533e04e95b7afd61bb1d51b6c263176435489/pydantic-2.13.2-py3-none-any.whl", hash = "sha256:a525087f4c03d7e7456a3de89b64cd693d2229933bb1068b9af6befd5563694e", size = 471947, upload-time = "2026-04-17T09:31:57.541Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/bb/4742f05b739b2478459bb16fa8470549518c802e06ddcf3f106c5081315e/pydantic_core-2.46.2.tar.gz", hash = "sha256:37bb079f9ee3f1a519392b73fda2a96379b31f2013c6b467fe693e7f2987f596", size = 471269, upload-time = "2026-04-17T09:10:07.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/91/089f517a725f29084364169437833ab0ae4da4d7a6ed9d4474db7f1412e6/pydantic_core-2.46.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d8060f42db3cd204871db0afd51fef54a13fa544c4dd48cdcae2e174ef40c8ba", size = 2106218, upload-time = "2026-04-17T09:10:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/92/23858ed1b58f2a134e50c2fdd0e34ea72721ccb257e1e9346514e1ccb5b9/pydantic_core-2.46.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:73a9d2809bd8d4a7cda4d336dc996a565eb4feaaa39932f9d85a65fa18382f28", size = 1948087, upload-time = "2026-04-17T09:11:58.639Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ac/e2240fccb4794e965817593d5a46cf5ea22f2001b73fe360b7578925b7d8/pydantic_core-2.46.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b0a2dee92dfaabcfb93629188c3e9cf74fdfc0f22e7c369cb444a98814a1e50", size = 1972931, upload-time = "2026-04-17T09:13:13.304Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/3b11dab2aa15c5c8ed20a01eb7aa432a78b8e3a4713659f7e58490a020a5/pydantic_core-2.46.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3098446ba8cf774f61cb8d4008c1dba14a30426a15169cd95ac3392a461193b1", size = 2040454, upload-time = "2026-04-17T09:13:47.895Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/39/c4cf5e1f1c6c34c53c0902039c95d81dc15cdd1f03634bd1a93f33e70a72/pydantic_core-2.46.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57c584af6c375ea3f826d8131a94cb212b3d9926eaff67117e3711bbff3a83a5", size = 2221320, upload-time = "2026-04-17T09:13:08.568Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/46/891035bc9e93538e754c3188424d24b5a69ec3ae5210fa01d483e99b3302/pydantic_core-2.46.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:547381cca999be88b4715a0ed7afa11f07fc7e53cb1883687b190d25a92c56cf", size = 2274559, upload-time = "2026-04-17T09:11:10.257Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d0/7af0b905b3148152c159c9caf203e7ecd9b90b76389f0862e6ab0cf1b2a3/pydantic_core-2.46.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:caeed15dcb1233a5a94bc6ff37ef5393cf5b33a45e4bdfb2d6042f3d24e1cb27", size = 2089239, upload-time = "2026-04-17T09:13:06.326Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bc/566afe02ba2de37712eece74ac7bfba322abd7916410bf90504f1b17ddad/pydantic_core-2.46.2-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:c05f53362568c75476b5c96659377a5dfd982cfbe5a5c07de5106d08a04efc4f", size = 2116182, upload-time = "2026-04-17T09:11:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5b/3fcb3a229bbfa23b0e3c65014057af0f9d51ec7a2d9f7adb282f41ff5ac8/pydantic_core-2.46.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2643ac7eae296200dbd48762a1c852cf2cad5f5e3eba34e652053cebf03becf8", size = 2172346, upload-time = "2026-04-17T09:10:46.472Z" },
+    { url = "https://files.pythonhosted.org/packages/43/9a/baa9e3aa70ea7bbcb9db0f87162a371649ac80c03e43eb54af193390cf17/pydantic_core-2.46.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:dc4620a47c6fe6a39f89392c00833a82fc050ce90169798f78a25a8d4df03b6e", size = 2179540, upload-time = "2026-04-17T09:11:21.881Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/46/912047a5427f949c909495704b3c8b9ead9d1c66f87e96606011beab1fcb/pydantic_core-2.46.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:78cb0d2453b50bf2035f85fd0d9cfabdb98c47f9c53ddb7c23873cd83da9560b", size = 2327423, upload-time = "2026-04-17T09:13:40.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bf/c5e661451dc9411c2ab88a244c1ba57644950c971486040dc200f77b69f4/pydantic_core-2.46.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f0c1cbb7d6112932cc188c6be007a5e2867005a069e47f42fe67bf5f122b0908", size = 2348652, upload-time = "2026-04-17T09:10:37.76Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b3/3219e7c522af54b010cf7422dcb11cc6616a4414d1ccd628b0d3f61c6af6/pydantic_core-2.46.2-cp311-cp311-win32.whl", hash = "sha256:c1ce5b2366f85cfdbf7f0907755043707f86d09a5b1b1acebbb7bf1600d75c64", size = 1974410, upload-time = "2026-04-17T09:13:27.392Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/29/e5cfac8a74c59873dfd47d3a1477c39ad9247639a7120d3e251a9ff12417/pydantic_core-2.46.2-cp311-cp311-win_amd64.whl", hash = "sha256:f1a6197eadff5bd0bb932f12bb038d403cb75db5b0b391e70e816a647745ddaf", size = 2071158, upload-time = "2026-04-17T09:09:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8b/b7b19b717cdb3675cb109de143f62d4dc62f5d4a0b9879b6f1ace62c6654/pydantic_core-2.46.2-cp311-cp311-win_arm64.whl", hash = "sha256:15e42885b283f87846ee79e161002c5c496ef747a73f6e47054f45a13d9035bc", size = 2043507, upload-time = "2026-04-17T09:09:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ec/2fafa4c86f5d2a69372c7cddef30925fd0e370b1efaf556609c1a0196d8a/pydantic_core-2.46.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ea1ad8c89da31512fe2d249cf0638fb666925bda341901541bc5f3311c6fcc9e", size = 2101729, upload-time = "2026-04-17T09:12:30.042Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/55/be5386c2c4b49af346e8a26b748194ff25757bbb6cf544130854e997af7a/pydantic_core-2.46.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b308da17b92481e0587244631c5529e5d91d04cb2b08194825627b1eca28e21e", size = 1951546, upload-time = "2026-04-17T09:10:10.585Z" },
+    { url = "https://files.pythonhosted.org/packages/29/92/89e273a055ce440e6636c756379af35ad86da9d336a560049c3ba5e41c80/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d333a50bdd814a917d8d6a7ee35ba2395d53ddaa882613bc24e54a9d8b129095", size = 1976178, upload-time = "2026-04-17T09:11:49.619Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b3/e4664469cf70c0cb0f7b2f5719d64e5968bb6f38217042c2afa3d3c4ba17/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1d00b99590c5bd1fabbc5d28b170923e32c1b1071b1f1de1851a4d14d89eb192", size = 2051697, upload-time = "2026-04-17T09:12:04.917Z" },
+    { url = "https://files.pythonhosted.org/packages/98/58/dbf68213ee06ce51cdd6d8c95f97980e646858c45bd96bd2dfb40433be73/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f0e686960ffe9e65066395af856ac2d52c159043144433602c50c221d81c1ba", size = 2233160, upload-time = "2026-04-17T09:12:00.956Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d3/68092aa0ee6c60ff4de4740eb82db3d4ce338ec89b3cecb978c532472f12/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d1128da41c9cb474e0a4701f9c363ec645c9d1a02229904c76bf4e0a194fde2", size = 2298398, upload-time = "2026-04-17T09:10:29.694Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/51/5d6155eb737db55b0ad354ca5f333ef009f75feb67df2d79a84bace45af6/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48649cf2d8c358d79586e9fb2f8235902fcaa2d969ec1c5301f2d1873b2f8321", size = 2094058, upload-time = "2026-04-17T09:12:10.995Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f3/eb4a986197d71319430464ff181226c95adc8f06d932189b158bae5a82f5/pydantic_core-2.46.2-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:b902f0fc7c2cf503865a05718b68147c6cd5d0a3867af38c527be574a9fa6e9d", size = 2130388, upload-time = "2026-04-17T09:12:41.159Z" },
+    { url = "https://files.pythonhosted.org/packages/56/00/44a9c4fe6d0f64b5786d6a8c649d6f0e34ba6c89b3663add1066e54451a2/pydantic_core-2.46.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e80011f808b03d1d87a8f1e76ae3da19a18eb706c823e17981dcf1fae43744fc", size = 2184245, upload-time = "2026-04-17T09:12:36.532Z" },
+    { url = "https://files.pythonhosted.org/packages/78/6b/685b98a834d5e3d1c34a1bde1627525559dd223b75075bc7490cdb24eb33/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b839d5c802e31348b949b6473f8190cddbf7d47475856d8ac995a373ee16ec59", size = 2186842, upload-time = "2026-04-17T09:13:04.054Z" },
+    { url = "https://files.pythonhosted.org/packages/22/64/caa2f5a2ac8b6113adaa410ccdf31ba7f54897a6e54cd0d726fc7e780c88/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:c6b1064f3f9cf9072e1d59dd2936f9f3b668bec1c37039708c9222db703c0d5b", size = 2336066, upload-time = "2026-04-17T09:12:13.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f9/7d2701bf82945b5b9e7df8347be97ef6a36da2846bfe5b4afec299ffe27b/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:37a68e6f2ac95578ce3c0564802404b27b24988649616e556c07e77111ed3f1d", size = 2363691, upload-time = "2026-04-17T09:13:42.972Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/65/0dab11574101522941055109419db3cc09db871643dc3fc74e2413215e5b/pydantic_core-2.46.2-cp312-cp312-win32.whl", hash = "sha256:d9ffa75a7ef4b97d6e5e205fabd4304ef01fec09e6f1bdde04b9ad1b07d20289", size = 1958801, upload-time = "2026-04-17T09:11:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2b/df84baa609c676f6450b8ecad44ea59146c805e3371b7b52443c0899f989/pydantic_core-2.46.2-cp312-cp312-win_amd64.whl", hash = "sha256:0551f2d2ddb68af5a00e26497f8025c538f73ef3cb698f8e5a487042cd2792a8", size = 2072634, upload-time = "2026-04-17T09:11:02.407Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4e/e1ce8029fc438086a946739bf9d596f70ff470aad4a8345555920618cabe/pydantic_core-2.46.2-cp312-cp312-win_arm64.whl", hash = "sha256:83aef30f106edcc21a6a4cc44b82d3169a1dbe255508db788e778f3c804d3583", size = 2026188, upload-time = "2026-04-17T09:13:11.083Z" },
+    { url = "https://files.pythonhosted.org/packages/07/2b/662e48254479a2d3450ba24b1e25061108b64339794232f503990c519144/pydantic_core-2.46.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:d26e9eea3715008a09a74585fe9becd0c67fbb145dc4df9756d597d7230a652c", size = 2101762, upload-time = "2026-04-17T09:10:13.87Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ab/bafd7c7503757ccc8ec4d1911e106fe474c629443648c51a88f08b0fe91a/pydantic_core-2.46.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:48b36e3235140510dc7861f0cd58b714b1cdd3d48f75e10ce52e69866b746f10", size = 1951814, upload-time = "2026-04-17T09:12:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/7549c2d57ba2e9a42caa5861a2d398dbe31c02c6aca783253ace59ce84f8/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36b1f99dc451f1a3981f236151465bcf995bbe712d0727c9f7b236fe228a8133", size = 1977329, upload-time = "2026-04-17T09:13:37.605Z" },
+    { url = "https://files.pythonhosted.org/packages/18/50/7ed4a8a0d478a4dca8f0134a5efa7193f03cc8520dd4c9509339fb2e5002/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8641c8d535c2d95b45c2e19b646ecd23ebba35d461e0ae48a3498277006250ab", size = 2051832, upload-time = "2026-04-17T09:12:49.771Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/16/bb35b193741c0298ddc5f5e4234269efdc0c65e2bcd198aa0de9b68845e4/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:20fb194788a0a50993e87013e693494ba183a2af5b44e99cf060bbae10912b11", size = 2233127, upload-time = "2026-04-17T09:11:04.449Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a5/98f4b637149185addea19e1785ea20c373cca31b202f589111d8209d9873/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9262d11d0cd11ee3303a95156939402bed6cedfe5ed0e331b95a283a4da6eb8b", size = 2297418, upload-time = "2026-04-17T09:11:25.929Z" },
+    { url = "https://files.pythonhosted.org/packages/36/90/93a5d21990b152da7b7507b7fddb0b935f6a0984d57ac3ec45a6e17777a2/pydantic_core-2.46.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac204542736aa295fa25f713b7fad6fc50b46ab7764d16087575c85f085174f3", size = 2093735, upload-time = "2026-04-17T09:12:06.908Z" },
+    { url = "https://files.pythonhosted.org/packages/14/22/b8b1ffdddf08b4e84380bcb67f41dbbf4c171377c1d36fc6290794bb2094/pydantic_core-2.46.2-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9a7c43a0584742dface3ca0daf6f719d46c1ac2f87cf080050f9ae052c75e1b2", size = 2127570, upload-time = "2026-04-17T09:11:53.906Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/26/e60d72b4e2d0ce1fa811044a974412ac1c567fe067d97b3e6b290530786e/pydantic_core-2.46.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fd05e1edb6a90ad446fa268ab09e59202766b837597b714b2492db11ee87fab9", size = 2183524, upload-time = "2026-04-17T09:11:30.092Z" },
+    { url = "https://files.pythonhosted.org/packages/35/32/36bec7584a1eefb17dec4dfa1c946d3fe4440f466c5705b8adfda69c9a9f/pydantic_core-2.46.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:91155b110788b5501abc7ea954f1d08606219e4e28e3c73a94124307c06efb80", size = 2185408, upload-time = "2026-04-17T09:10:57.228Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d6/1a5689d873620efd67d6b163db0c444c056adb0849b5bc33e2b9f09665a6/pydantic_core-2.46.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e4e2c72a529fa03ff228be1d2b76944013f428220b764e03cc50ada67e17a42c", size = 2335171, upload-time = "2026-04-17T09:11:43.369Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8e/675104802abe8ef502b072050ee5f2e915251aa1a3af87e1015ce31ec42d/pydantic_core-2.46.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:56291ec1a11c3499890c99a8fd9053b47e60fe837a77ec72c0671b1b8b3dce24", size = 2362743, upload-time = "2026-04-17T09:10:18.333Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/bc/86c5dde4fa6e24467680eef5047da3c1a19be0a527d0d8e14aa76b39307c/pydantic_core-2.46.2-cp313-cp313-win32.whl", hash = "sha256:b50f9c5f826ddca1246f055148df939f5f3f2d0d96db73de28e2233f22210d4c", size = 1958074, upload-time = "2026-04-17T09:12:38.622Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/97/2537e8c1282b2c4eb062580c0d7a4339e10b072b803d1ee0b7f1f0a5c22c/pydantic_core-2.46.2-cp313-cp313-win_amd64.whl", hash = "sha256:251a57788823230ca8cbc99e6245d1a2ed6e180ec4864f251c94182c580c7f2e", size = 2071741, upload-time = "2026-04-17T09:13:32.405Z" },
+    { url = "https://files.pythonhosted.org/packages/da/aa/2ee75798706f9dbc4e76dbe59e41a396c5c311e3d6223b9cf6a5fa7780be/pydantic_core-2.46.2-cp313-cp313-win_arm64.whl", hash = "sha256:315d32d1a71494d6b4e1e14a9fa7a4329597b4c4340088ad7e1a9dafbeed92a9", size = 2025955, upload-time = "2026-04-17T09:10:15.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/96/a50ccb6b539ae780f73cea74905468777680e30c6c3bdf714b9d4c116ea0/pydantic_core-2.46.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4f59b45f3ef8650c0c736a57f59031d47ed9df4c0a64e83796849d7d14863a2d", size = 2097111, upload-time = "2026-04-17T09:10:49.617Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5f/fdead7b3afa822ab6e5a18ee0ecffd54937de1877c01ed13a342e0fb3f07/pydantic_core-2.46.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3a075a29ebef752784a91532a1a85be6b234ccffec0a9d7978a92696387c3da6", size = 1951904, upload-time = "2026-04-17T09:12:32.062Z" },
+    { url = "https://files.pythonhosted.org/packages/95/e0/1c5d547e550cdab1bec737492aa08865337af6fe7fc9b96f7f45f17d9519/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d12d786e30c04a9d307c5d7080bf720d9bac7f1668191d8e37633a9562749e2", size = 1978667, upload-time = "2026-04-17T09:11:35.589Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/cb/665ce629e218c8228302cb94beff4f6531082a2c87d3ecc3d5e63a26f392/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d5e6d6343b0b5dcacb3503b5de90022968da8ed0ab9ab39d3eda71c20cbf84e", size = 2046721, upload-time = "2026-04-17T09:11:47.725Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e9/6cb2cf60f54c1472bbdfce19d957553b43dbba79d1d7b2930a195c594785/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:233eebac0999b6b9ba76eb56f3ec8fce13164aa16b6d2225a36a79e0f95b5973", size = 2228483, upload-time = "2026-04-17T09:12:08.837Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/93e018dd5571f781ebaeda8c0cf65398489d5bee9b1f484df0b6149b43b9/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9cc0eee720dd2f14f3b7c349469402b99ad81a174ab49d3533974529e9d93992", size = 2294663, upload-time = "2026-04-17T09:12:52.053Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/4f/49e57ca55c770c93d9bb046666a54949b42e3c9099a0c5fe94557873fe30/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83ee76bf2c9910513dbc19e7d82367131fa7508dedd6186a462393071cc11059", size = 2098742, upload-time = "2026-04-17T09:13:45.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b0/6e46b5cd3332af665f794b8cdeea206618a8630bd9e7bcc36864518fce81/pydantic_core-2.46.2-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:d61db38eb4ee5192f0c261b7f2d38e420b554df8912245e3546aee5c45e2fd78", size = 2125922, upload-time = "2026-04-17T09:12:54.304Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/40850c81585be443a2abfdf7f795f8fae831baf8e2f9b2133c8246ac671c/pydantic_core-2.46.2-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8f09a713d17bcd55da8ab02ebd9110c5246a49c44182af213b5212800af8bc83", size = 2183000, upload-time = "2026-04-17T09:10:59.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/af/8493d7dfa03ebb7866909e577c6aa65ea0de7377b86023cc51d0c8e11db3/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:30cacc5fb696e64b8ef6fd31d9549d394dd7d52760db072eecb98e37e3af1677", size = 2180335, upload-time = "2026-04-17T09:12:57.01Z" },
+    { url = "https://files.pythonhosted.org/packages/72/5b/1f6a344c4ffdf284da41c6067b82d5ebcbd11ce1b515ae4b662d4adb6f61/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:7ccfb105fcfe91a22bbb5563ad3dc124bc1aa75bfd2e53a780ab05f78cdf6108", size = 2330002, upload-time = "2026-04-17T09:12:02.958Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ff/9a694126c12d6d2f48a0cafa6f8eef88ef0d8825600e18d03ff2e896c3b2/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:13ffef637dc8370c249e5b26bd18e9a80a4fca3d809618c44e18ec834a7ca7a8", size = 2359920, upload-time = "2026-04-17T09:10:27.764Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c8/3a35c763d68a9cb2675eb10ef242cf66c5d4701b28ae12e688d67d2c180e/pydantic_core-2.46.2-cp314-cp314-win32.whl", hash = "sha256:1b0ab6d756ca2704a938e6c31b53f290c2f9c10d3914235410302a149de1a83e", size = 1953701, upload-time = "2026-04-17T09:13:30.021Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/6a/f2726a780365f7dfd89d62036f984f7acb99978c60c5e1fa7c0cb898ed11/pydantic_core-2.46.2-cp314-cp314-win_amd64.whl", hash = "sha256:99ebade8c9ada4df975372d8dd25883daa0e379a05f1cd0c99aa0c04368d01a6", size = 2071867, upload-time = "2026-04-17T09:10:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/79/76baacb9feba3d7c399b245ca1a29c74ea0db04ea693811374827eec2290/pydantic_core-2.46.2-cp314-cp314-win_arm64.whl", hash = "sha256:de87422197cf7f83db91d89c86a21660d749b3cd76cd8a45d115b8e675670f02", size = 2017252, upload-time = "2026-04-17T09:10:26.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3b/77c26938f817668d9ad9bab1a905cb23f11d9a3d4bf724d429b3e55a8eaf/pydantic_core-2.46.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:236f22b4a206b5b61db955396b7cf9e2e1ff77f372efe9570128ccfcd6a525eb", size = 2094545, upload-time = "2026-04-17T09:12:19.339Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/de/42c13f590e3c260966aa49bcdb1674774f975467c49abd51191e502bea28/pydantic_core-2.46.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c2012f64d2cd7cca50f49f22445aa5a88691ac2b4498ee0a9a977f8ca4f7289f", size = 1933953, upload-time = "2026-04-17T09:09:55.889Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/84/ebe3ebb3e2d8db656937cfa6f97f544cb7132f2307a4a7dfdcd0ea102a12/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d07d6c63106d3a9c9a333e2636f9c82c703b1a9e3b079299e58747964e4fdb72", size = 1974435, upload-time = "2026-04-17T09:10:12.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/15/0bf51ca6709477cd4ef86148b6d7844f3308f029eac361dd0383f1e17b1a/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c326a2b4b85e959d9a1fc3a11f32f84611b6ec07c053e1828a860edf8d068208", size = 2031113, upload-time = "2026-04-17T09:10:00.752Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ae/b7b5af9b79db036d9e61a44c481c17a213dc8fc4b8b71fe6875a72fc778b/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac8a65e798f2462552c00d2e013d532c94d646729dda98458beaf51f9ec7b120", size = 2236325, upload-time = "2026-04-17T09:10:33.227Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ae/ecef7477b5a03d4a499708f7e75d2836452ebb70b776c2d64612b334f57a/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a3c2bc1cc8164bedbc160b7bb1e8cc1e8b9c27f69ae4f9ae2b976cdae02b2dd", size = 2278135, upload-time = "2026-04-17T09:10:23.287Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e4/2f9d82faa47af6c39fc3f120145fd915971e1e0cb6b55b494fad9fdf8275/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e69aa5e10b7e8b1bb4a6888650fd12fcbf11d396ca11d4a44de1450875702830", size = 2109071, upload-time = "2026-04-17T09:11:06.149Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9c/677cf10873fbd0b116575ab7b97c90482b21564f8a8040beb18edef7a577/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4e6df5c3301e65fb42bc5338bf9a1027a02b0a31dc7f54c33775229af474daf0", size = 2106028, upload-time = "2026-04-17T09:10:51.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/53/6a06183544daba51c059123a2064a99039df25f115a06bdb26f2ea177038/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c2f6e32548ac8d559b47944effcf8ae4d81c161f6b6c885edc53bc08b8f192d", size = 2164816, upload-time = "2026-04-17T09:11:56.187Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6f/10fcdd9e3eca66fc828eef0f6f5850f2dd3bca2c59e6e041fb8bc3da39be/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:b089a81c58e6ea0485562bbbbbca4f65c0549521606d5ef27fba217aac9b665a", size = 2166130, upload-time = "2026-04-17T09:10:03.804Z" },
+    { url = "https://files.pythonhosted.org/packages/29/83/92d3fd0e0156cad2e3cb5c26de73794af78ac9fa0c22ab666e566dd67061/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:7f700a6d6f64112ae9193709b84303bbab84424ad4b47d0253301aabce9dfc70", size = 2316605, upload-time = "2026-04-17T09:12:45.249Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f1/facffdb970981068219582e499b8d0871ed163ffcc6b347de5c412669e4c/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:67db6814beaa5fefe91101ec7eb9efda613795767be96f7cf58b1ca8c9ca9972", size = 2358385, upload-time = "2026-04-17T09:09:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/a1/b8160b2f22b2199467bc68581a4ed380643c16b348a27d6165c6c242d694/pydantic_core-2.46.2-cp314-cp314t-win32.whl", hash = "sha256:32fbc7447be8e3be99bf7869f7066308f16be55b61f9882c2cefc7931f5c7664", size = 1942373, upload-time = "2026-04-17T09:12:59.594Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/90/db89acabe5b150e11d1b59fe3d947dda2ef6abbfef5c82f056ff63802f5d/pydantic_core-2.46.2-cp314-cp314t-win_amd64.whl", hash = "sha256:b317a2b97019c0b95ce99f4f901ae383f40132da6706cdf1731066a73394c25c", size = 2052078, upload-time = "2026-04-17T09:10:19.96Z" },
+    { url = "https://files.pythonhosted.org/packages/97/32/e19b83ceb07a3f1bb21798407790bbc9a31740158fd132b94139cb84e16c/pydantic_core-2.46.2-cp314-cp314t-win_arm64.whl", hash = "sha256:7dcb9d40930dfad7ab6b20bcc6ca9d2b030b0f347a0cd9909b54bd53ead521b1", size = 2016941, upload-time = "2026-04-17T09:12:34.447Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ec/e91aa08df1c33d5e3c2b60c07a1eca9f21809728a824c7b467bb3bda68b5/pydantic_core-2.46.2-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:7c5a5b3dbb9e8918e223be6580da5ffcf861c0505bbc196ebed7176ce05b7b4e", size = 2105046, upload-time = "2026-04-17T09:10:55.614Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/73/27112400a0452e375290e7c40aef5cc9844ac0920fb1029238cfc68121fa/pydantic_core-2.46.2-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:bc1e8ce33d5a337f2ba862e0719b8201cd54aaed967406c748e009191d47efdd", size = 1940029, upload-time = "2026-04-17T09:12:21.5Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/44/3d39f782bc82ddd0b2d82bde83b408aa40a332cdf6f3018acb34e3d4dcfc/pydantic_core-2.46.2-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b737c0b280f41143266445de2689c0e49c79307e51c44ce3a77fef2bedad4994", size = 1987772, upload-time = "2026-04-17T09:10:02.357Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/1a/0242e5b7b6cf51dbccc065029f0420107b6bf7e191fcb918f5cb71218acf/pydantic_core-2.46.2-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b877d597afb82b4898e35354bba55de6f7f048421ae0edadbb9886ec137b532", size = 2138468, upload-time = "2026-04-17T09:11:51.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/66c146f421178641bda880b0267c0d57dd84f5fec9ecc8e46be17b480742/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e9fcabd1857492b5bf16f90258babde50f618f55d046b1309972da2396321ff9", size = 2091621, upload-time = "2026-04-17T09:12:47.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b2/c28419aa9fc8055f4ac8e801d1d11c6357351bfa4321ed9bafab3eb98087/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:fb3ec2c7f54c07b30d89983ce78dc32c37dd06a972448b8716d609493802d628", size = 1937059, upload-time = "2026-04-17T09:10:53.554Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ce/cd0824a2db213dc17113291b7a09b9b0ccd9fbf97daa4b81548703341baf/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:130a6c837d819ef33e8c2bf702ed2c3429237ea69807f1140943d6f4bdaf52fa", size = 1997278, upload-time = "2026-04-17T09:12:23.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/69/47283fe3c0c967d3e9e9cd6c42b70907610c8a6f8d6e8381f1bb55f8006c/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2e25417cec5cd9bddb151e33cb08c50160f317479ecc02b22a95ec18f8fe004", size = 2147096, upload-time = "2026-04-17T09:12:43.124Z" },
+    { url = "https://files.pythonhosted.org/packages/16/d5/dec7c127fa722ff56e1ccf1e960ae1318a9f66742135e97bf9771447216f/pydantic_core-2.46.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c3ad79ed32004d9de91cacd4b5faaff44d56051392fe1d5526feda596f01af25", size = 2107613, upload-time = "2026-04-17T09:10:36.269Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/35/975c109b337260a71c93198baf663982b6b39fe3e584e279548a0969e5d4/pydantic_core-2.46.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d157c48d28eebe5d46906de06a6a2f2c9e00b67d3e42de1f1b9c2d42b810f77c", size = 1947099, upload-time = "2026-04-17T09:12:15.304Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/11/52a971a0f9218631690274be533f05e5ddde5547f0823bb3e9dfd1be49f6/pydantic_core-2.46.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42c6471288dedc979ac8400d9c9770f03967dd187db1f8d3405d4d182cc714", size = 2133866, upload-time = "2026-04-17T09:12:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7a/33d94d0698602b2d1712e78c703a33952eb2ca69e02e8e4b208e7f6602b5/pydantic_core-2.46.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4f27bc4801358dc070d6697b41237fce9923d8e69a1ce1e95606ac36c1552dc1", size = 2161721, upload-time = "2026-04-17T09:11:16.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cb/0df7ee0a148e9ce0968a80787967ddca9f6b3f8a49152a881b88da262701/pydantic_core-2.46.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e094a8f85db41aa7f6a45c5dac2950afc9862e66832934231962252b5d284eed", size = 2180175, upload-time = "2026-04-17T09:11:41.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a8/258a32878140347532be4e44c6f3b1ace3b52b9c9ca7548a65ce18adf4b4/pydantic_core-2.46.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:807eeda5551f6884d3b4421578be37be50ddb7a58832348e99617a6714a73748", size = 2319882, upload-time = "2026-04-17T09:10:21.872Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b9/5071c298a0f91314a5402b8c56e0efbcebe77085327d0b4df7dc9cb0b674/pydantic_core-2.46.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fcaa1c3c846a7f6686b38fe493d1b2e8007380e293bfef6a9354563c026cbf36", size = 2348065, upload-time = "2026-04-17T09:11:08.263Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f3/0a7087e5f861d66ca64ce927230b397cc264c87b712156e6a93b26a459c8/pydantic_core-2.46.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:154dbfdfb11b8cbd8ff4d00d0b81e3d19f4cb4bedd5aa9f091060ba071474c6a", size = 2192159, upload-time = "2026-04-17T09:11:20.123Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
## Summary

- Adds the top-level `examples/` directory convention (`examples/<topic>/<lang>/`, language always nested for stable URLs).
- Ships the inaugural example: `examples/rag/python/` — a guided walkthrough of every method on `client.rag`.
- Adds a scheduled GitHub Action that runs every example's smoke test weekly against the latest published SDK so drift surfaces fast.
- Gitignores internal planning artifacts under `docs/superpowers/`.

## Commits

1. `chore: gitignore docs/superpowers/ and add baseline ignore rules`
2. `feat(examples): add examples directory index`
3. `feat(examples): add RAG example (python)`
4. `ci: add scheduled smoke test for examples`
5. `fix(examples): scope rag test search to current session`

## Required before merge

- [x] `cerebe>=0.5.0` published to PyPI (already live).
- [ ] `CEREBE_API_KEY` set as a repository Actions secret with `rag:read`, `rag:write`, `rag:delete` scopes (required by the scheduled smoke workflow).

## Verified locally

- [x] `make install` on a clean venv — `uv sync --extra dev` resolves cleanly on Python 3.12.
- [x] `make demo` — all 7 steps green, searches return thematically correct top results, cleanup deletes all 5 docs, exit 0.
- [x] `make test` — all 5 smoke tests pass in ~3s.
- [x] Bogus key (`ck_live_invalid_…`) → preflight fails with friendly HTTP 401 message, no traceback, exit 1.
- [x] Empty key (`CEREBE_API_KEY=""`) → demo exits 1 with actionable 3-step instructions; tests skip cleanly (pytest exit 5).

## Observed during implementation

While verifying, hit two platform-side quirks worth flagging — not blockers for this PR, but worth triaging:

1. **Ghost vectors after `delete_document`.** `stats` and `list_documents` correctly report 0 after a source is deleted, but `search` can still return chunks from that deleted source (observed up to ~2 minutes later). The metadata store and the vector index appear to be out of sync on the delete path. Hardened `test_search_finds_embedded` to scope its search with `source_pattern` so it isn't a hostage to orphan vectors.
2. **`source_pattern` is a prefix match, not a glob.** `source_pattern="foo/*"` returns zero results; `source_pattern="foo/"` returns all sources under `foo/`. The parameter name suggests glob semantics — worth either renaming (e.g. `source_prefix`) or documenting clearly in the SDK docstring.

## Out of scope

- TypeScript variant (follow-up).
- Additional example topics (follow-ups as more features become public-facing).
- Shared utility code across examples (explicitly rejected in the design — every example is clone-and-copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a scheduled/PR GitHub Actions workflow that runs live API smoke tests against production using a repo secret, which can introduce CI flakiness/cost and depends on correct secret scoping.
> 
> **Overview**
> **Adds a new `examples/` framework and first runnable example.** Introduces `examples/<topic>/<lang>/` conventions with an index (`examples/README.md`), updates the root `README.md` to link to examples, and adds an end-to-end Python RAG walkthrough under `examples/rag/python/` (guided `demo.py`, `pytest` live smoke tests, sample docs, `Makefile`, `.env.example`, and `uv`-managed deps pinned to `cerebe>=0.5.0`).
> 
> **Adds CI drift detection for examples.** New `examples-smoke` GitHub Actions workflow runs on schedule/PR/push across OS + Python versions, upgrades `cerebe` to latest before running each example’s `make test`, and uploads logs on failure; also adds baseline `.gitignore` entries (including `docs/superpowers/` and env/venv caches).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b5da344287c9cf56fe6c9edf3030b07155dd75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->