### PR TITLE
docs(examples): frame examples as the cognitive-services slice of the family

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 # Cerebe Examples
 
-Runnable examples that show how to use the Cerebe platform. Each example is self-contained — clone the repo, `cd` into it, follow its README, and it works.
+Runnable examples for **Cerebe's cognitive services** — the Memory, Knowledge, Models, and Meta-Learning APIs — through the Python and TypeScript SDKs. These show the cognitive-infrastructure slice of the Cerebe family; for the build lifecycle (Blueprint / Plan / Factory) see [cerebe.ai](https://cerebe.ai).
 
-Every example lives under `examples/<topic>/<language>/`. The language subdirectory is always present (even when only one language ships today) so that deep links stay stable as more languages are added.
+Each example is self-contained — clone the repo, `cd` into it, follow its README, and it works. Every example lives under `examples/<topic>/<language>/`. The language subdirectory is always present (even when only one language ships today) so that deep links stay stable as more languages are added.
 
 ## Available examples
 


### PR DESCRIPTION
## What & why

Frames `examples/` as the **cognitive-services slice** of the Cerebe family — one Axis-2 component (Memory / Models / Services), not the whole product — so the examples README is consistent with the front-door README's family framing (repo-prep handoff #600; house-brand design momentiq-ai/dark-factory-platform#583).

Audited the April shell for stale references: **no raw `dark-factory` URLs** (the examples + `examples-smoke.yml` were already `cerebe.ai`-branded). Only the intro framing changes; the runnable RAG example and its smoke workflow are unchanged.

## Type of change

- [x] Docs / examples

## Reviewer notes

- Sibling PRs: #45 (README identity + LICENSE), #46 (governance scaffold).
- **Please do not auto-merge** — outward-facing docs; PJ reviews.
- No behavior change; `examples-smoke.yml` and the RAG demo/tests are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)