### PR TITLE
feat: install.sh — curl|sh installer for the Dark Factory CLI (pre-Homebrew)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Cerebe / Dark Factory CLI installer — downloads the released binaries from
+# momentiq-ai/cerebe GitHub Releases, verifies their SHA256 checksums, and
+# installs `dark-factory` + `cyclone` onto PATH. POSIX sh; macOS + Linux.
+#
+#   curl -fsSL https://raw.githubusercontent.com/momentiq-ai/cerebe/main/install.sh | sh
+#
+# Env overrides:
+#   CEREBE_VERSION=4.0.0     pin a version (default: latest release)
+#   CEREBE_INSTALL_DIR=DIR   install target (default: /usr/local/bin, or ~/.local/bin
+#                            if the former is not writable)
+set -eu
+
+REPO="momentiq-ai/cerebe"
+BINARIES="dark-factory cyclone"
+VERSION="${CEREBE_VERSION:-}"
+
+log()  { printf '  %s\n' "$*"; }
+err()  { printf 'cerebe-install: %s\n' "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || err "required tool not found: $1"; }
+
+need curl
+need tar
+# One of sha256sum / shasum must exist for integrity verification.
+if command -v sha256sum >/dev/null 2>&1; then SHACHK="sha256sum -c"; 
+elif command -v shasum   >/dev/null 2>&1; then SHACHK="shasum -a 256 -c";
+else err "need sha256sum or shasum for checksum verification"; fi
+
+# --- detect os/arch → the GoReleaser asset suffix -------------------------
+os=$(uname -s); arch=$(uname -m)
+case "$os" in
+  Linux)  OS=linux ;;
+  Darwin) OS=darwin ;;
+  *) err "unsupported OS: $os (Windows: download the .zip from the Releases page)";;
+esac
+case "$arch" in
+  x86_64|amd64) ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) err "unsupported arch: $arch";;
+esac
+TARGET="${OS}_${ARCH}"
+
+# --- resolve version (default: latest release tag) ------------------------
+if [ -z "$VERSION" ]; then
+  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | sed 's/.*"tag_name" *: *"v\{0,1\}\([^"]*\)".*/\1/')
+  [ -n "$VERSION" ] || err "could not resolve the latest release version from GitHub"
+fi
+BASE="https://github.com/${REPO}/releases/download/v${VERSION}"
+log "Installing Dark Factory CLI v${VERSION} (${TARGET}) from ${REPO} Releases"
+
+# --- install dir (writable, on PATH) --------------------------------------
+# An explicit CEREBE_INSTALL_DIR is honored (created if needed). Only the DEFAULT
+# (/usr/local/bin) falls back to ~/.local/bin when it is not writable.
+if [ -n "${CEREBE_INSTALL_DIR:-}" ]; then
+  DIR="$CEREBE_INSTALL_DIR"; mkdir -p "$DIR" || err "cannot create CEREBE_INSTALL_DIR=$DIR"
+  [ -w "$DIR" ] || err "CEREBE_INSTALL_DIR=$DIR is not writable"
+else
+  DIR="/usr/local/bin"
+  if [ ! -d "$DIR" ] || [ ! -w "$DIR" ]; then
+    DIR="$HOME/.local/bin"; mkdir -p "$DIR"
+    log "Note: /usr/local/bin not writable → installing to $DIR (ensure it is on PATH)"
+  fi
+fi
+
+# --- download + verify + extract each binary ------------------------------
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT; cd "$tmp"
+curl -fsSLO "${BASE}/checksums.txt" || err "could not download checksums.txt for v${VERSION}"
+for bin in $BINARIES; do
+  asset="${bin}_${VERSION}_${TARGET}.tar.gz"
+  log "→ ${asset}"
+  curl -fsSLO "${BASE}/${asset}" || err "download failed: ${asset}"
+  # Materialize THIS asset's checksum line; fail hard if absent (an empty grep
+  # piped to the checker can exit 0), then verify, then extract.
+  grep " ${asset}\$" checksums.txt > "${asset}.sha256" \
+    || err "no checksum entry for ${asset} — refusing to install unverified"
+  [ -s "${asset}.sha256" ] || err "empty checksum entry for ${asset}"
+  $SHACHK "${asset}.sha256" >/dev/null || err "checksum mismatch for ${asset} — refusing to install"
+  tar -xzf "$asset" "$bin"
+  chmod 0755 "$bin"
+  mv -f "$bin" "$DIR/$bin"
+done
+
+printf '\nInstalled: %s → %s\n' "$BINARIES" "$DIR"
+printf 'Verify:    dark-factory --version   (expect v%s)\n' "$VERSION"
+case ":$PATH:" in *":$DIR:"*) : ;; *) printf 'PATH:      add %s to your PATH\n' "$DIR";; esac


### PR DESCRIPTION
The pre-Homebrew install answer for the Dark Factory CLI binaries published to this repo's Releases. **Today there is no one-liner** — `dark-factory` went private (so `go install` / the source `install.sh` are dead for external users), and installing means manually curl-ing + verifying + extracting two tarballs. This adds:

```sh
curl -fsSL https://raw.githubusercontent.com/momentiq-ai/cerebe/main/install.sh | sh
```

## What it does
- Auto-detects OS/arch → the GoReleaser asset (`linux`/`darwin` × `amd64`/`arm64`; Windows users get a pointer to the `.zip`).
- Resolves the **latest** release tag by default; `CEREBE_VERSION=4.0.0` pins one.
- Downloads `dark-factory` + `cyclone`, **verifies SHA256 against `checksums.txt`, and REFUSES** on mismatch or a missing entry (materializes the line + non-empty check, then `sha256sum`/`shasum -c` — never a bare `grep | sha` pipe that can exit 0). Same integrity discipline as the worker Dockerfile.
- `CEREBE_INSTALL_DIR` override (honored + created); default `/usr/local/bin`, `~/.local/bin` fallback.

## Verified
- **Live against v4.0.0**: installs both binaries; `dark-factory --version` → `v4.0.0`, `cyclone --version` → `v4.0.0`.
- **Negative-tested**: a well-formed-but-wrong checksum is refused (no install); the correct hash verifies.
- Explicit `CEREBE_INSTALL_DIR` is honored (regression-fixed during testing).

## For a human — one positioning call
This PR adds only the **mechanism** (`install.sh`). The README is the cognitive-services SDK product (`@cerebe/sdk`); whether/how to surface a CLI-install one-liner on this public brand property is your editorial call — I deliberately left the README untouched.

It also unblocks CI / AI-agent installs, which Homebrew never covers; the tap later layers on top of these same releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)