### PR TITLE
docs: pin the front door to stable v8.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ reviewed evidence. It's **free to use**, a pair of static binaries (`cerebe` + `
 no Node or Python runtime, and local review runs through your existing AI-app subscriptions
 (no API keys).
 
-Current stable release: **[v8.4.0](https://github.com/momentiq-ai/cerebe/releases/tag/v8.4.0)**
+Current stable release: **[v8.4.1](https://github.com/momentiq-ai/cerebe/releases/tag/v8.4.1)**
 ([all releases](https://github.com/momentiq-ai/cerebe/releases)).
 
 ```bash
 # Install the cerebe + cyclone binaries (checksum-verified) onto PATH — macOS/Linux
 curl -fsSL https://raw.githubusercontent.com/momentiq-ai/cerebe/main/install.sh | sh
-cerebe --version    # cerebe v8.4.0
+cerebe --version    # cerebe v8.4.1
 cyclone --version   # installed alongside
 ```
 
-Pin a version with `CEREBE_VERSION=8.4.0`. On Windows, download the `cerebe_*_windows_*.zip`
+Pin a version with `CEREBE_VERSION=8.4.1`. On Windows, download the `cerebe_*_windows_*.zip`
 and `cyclone_*_windows_*.zip` archives from the
 [Releases](https://github.com/momentiq-ai/cerebe/releases) page.
 
@@ -248,13 +248,13 @@ backend. See [cerebe.ai](https://cerebe.ai).
 
 ## What's new in v8
 
-Shipped in the current stable **[v8.4.0](https://github.com/momentiq-ai/cerebe/releases/tag/v8.4.0)** binary
+Shipped in the current stable **[v8.4.1](https://github.com/momentiq-ai/cerebe/releases/tag/v8.4.1)** binary
 (and the matching `cyclone`). Full notes live on the
 [Releases](https://github.com/momentiq-ai/cerebe/releases) page.
 
 | Surface | What landed |
 |---|---|
-| **`cerebe watch`** | Live factory-floor TUI: rounds, critic lanes, findings, platform chip. `--json` for agents. Root picker + attach + dirty chip when the repo has linked worktrees. |
+| **`cerebe watch`** | Live factory-floor TUI: rounds, critic lanes, findings, platform chip. `--json` for agents. Root picker + attach + dirty chip. **v8.4.1:** on-screen live keys, inverted selected row, picker opens without blocking on a full worktree scan. |
 | **`cyclone doc`** | One verb for registered doc types (scaffold, write, list, resolve). |
 | **`cyclone objectives` / `decisions` / `prove`** | Verifiable objectives, the decision ledger, and closeout proof. |
 | **`cerebe review --incremental`** | Re-review only the delta since the last round of the same change. |

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/momentiq-ai/cerebe/main/install.sh | sh
 #
 # Env overrides:
-#   CEREBE_VERSION=8.4.0     pin a version (default: latest stable release)
+#   CEREBE_VERSION=8.4.1     pin a version (default: latest stable release)
 #   CEREBE_INSTALL_DIR=DIR   install target (default: /usr/local/bin, or ~/.local/bin
 #                            if the former is not writable)
 set -eu


### PR DESCRIPTION
## What & why

`v8.4.1` is now the latest stable Cerebe Release (promoted from `v8.4.1-beta.3`).
Bump the hardcoded version pins on the public front door and note the watch
dogfood that landed in that tag (live keys, inverted selection, non-blocking picker).

The release badge already tracks latest; these are the prose pins.

## Type of change

- [x] Docs / examples

## Checklist

- [x] I read CONTRIBUTING.md.
- [x] This PR is one focused, logical change.
- [x] I am not committing secrets, API keys, or `.env` files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f33047ec61eb86a7f5729ab723c2e482b899ca3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->